### PR TITLE
Fixed small typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ lp.addConstraint(new Row().Add(y, 1), 'GE', 95 - 90, 'meet demand of y')
 
 console.log(lp.dumpProgram());
 console.log(lp.solve());
-console.log('objective =', lp.getObjective())
+console.log('objective =', lp.getObjectiveValue())
 console.log('x =', lp.get(x));
 console.log('y =', lp.get(y));
 console.log('machineatime =', lp.calculate(machineatime));


### PR DESCRIPTION
Hi,

I've spotted a small typo in the README file that was stopping the code from running.  I believe that the instead of getObjective (which matches the lp_solve C method name) it should be getObjectiveValue.

Cheers,
Sean.
