### PR TITLE
- provide isBinary boolean parameter to addColumn function

### DIFF
--- a/LinearProgram.js
+++ b/LinearProgram.js
@@ -19,8 +19,8 @@ LinearProgram.prototype.setOutputFile = function(fname) {
 	return this;
 }
 
-LinearProgram.prototype.addColumn = function(name, isInteger) {
-	
+LinearProgram.prototype.addColumn = function(name, isInteger, isBinary) {
+
 	var id = this.Columns[name] = Object.keys(this.Columns).length + 1;
 
 	if (name === undefined) {
@@ -32,6 +32,10 @@ LinearProgram.prototype.addColumn = function(name, isInteger) {
 	if (isInteger === true) {
 		this.lp_solve.setColumnInteger(id, true);
 	}
+
+  if (isBinary === true) {
+    this.lp_solve.setColumnBinary(id, true);
+  }
 
 	return name;
 }
@@ -102,9 +106,9 @@ LinearProgram.SolveResult = {
 LinearProgram.prototype.solve = function() {
 	var res = this.lp_solve.solve();
 
-	if (res == 0 || res == 1 || res ==9) 
+	if (res == 0 || res == 1 || res ==9)
 		this.solutionVariables = this.getSolutionVariables();
-	
+
 	return { code: res, description: LinearProgram.SolveResult[res] };
 }
 

--- a/lp_solve.cc
+++ b/lp_solve.cc
@@ -41,6 +41,7 @@ void LinearProgram::Init(Handle<Object> exports) {
 	NODE_SET_PROTOTYPE_METHOD(tpl, "setOutputFile", LinearProgram::SetOutputFile);
 	NODE_SET_PROTOTYPE_METHOD(tpl, "addColumn", LinearProgram::AddColumn);
 	NODE_SET_PROTOTYPE_METHOD(tpl, "setColumnInteger", LinearProgram::SetColumnInteger);
+  NODE_SET_PROTOTYPE_METHOD(tpl, "setColumnBinary", LinearProgram::SetColumnBinary);
 	NODE_SET_PROTOTYPE_METHOD(tpl, "addConstraint", LinearProgram::AddConstraint);
 	NODE_SET_PROTOTYPE_METHOD(tpl, "setObjective", LinearProgram::SetObjective);
 	NODE_SET_PROTOTYPE_METHOD(tpl, "solve", LinearProgram::Solve);
@@ -105,7 +106,7 @@ NAN_METHOD(LinearProgram::AddColumn) {
 	set_col_name(obj->lp, i, col_string);
 
 	delete col_string;
-	
+
 	NanReturnUndefined();
 }
 
@@ -119,6 +120,18 @@ NAN_METHOD(LinearProgram::SetColumnInteger) {
   	set_int(obj->lp, columnId, isInteger);
 
 	NanReturnUndefined();
+}
+
+NAN_METHOD(LinearProgram::SetColumnBinary) {
+  NanScope();
+  LinearProgram* obj = node::ObjectWrap::Unwrap<LinearProgram>(args.This());
+
+  int columnId = Handle<Number>::Cast(args[0])->Int32Value();
+  bool isBinary = Handle<Array>::Cast(args[1])->BooleanValue();
+
+    set_binary(obj->lp, columnId, isBinary);
+
+  NanReturnUndefined();
 }
 
 NAN_METHOD(LinearProgram::AddConstraint) {

--- a/lp_solve.h
+++ b/lp_solve.h
@@ -26,6 +26,7 @@ private:
 	static NAN_METHOD(SetOutputFile);
 	static NAN_METHOD(AddColumn);
 	static NAN_METHOD(SetColumnInteger);
+  static NAN_METHOD(SetColumnBinary);
 	static NAN_METHOD(AddConstraint);
 	static NAN_METHOD(SetObjective);
 	static NAN_METHOD(GetObjectiveValue);


### PR DESCRIPTION
- if isBinary true invoke setColumnBinary
- which should call set_binary() in a similar fashion to how SetColumnInteger called set_int()
- adding a binary constraint to a column is similar to setting an integer
- i.e. lp.addColumn('x', true) for integer variable can now be lp.addColumn('x', false, true) or lp.addColumn('x', true, true) for that matter
