### PR TITLE
Allow newer nan version to support newer node versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "bindings": "~1.2.1",
-    "nan": "2.1.0"
+    "nan": "^2.1.0"
   },
   "devDependencies": {
     "tap": "~0.4.6"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lp_solve",
   "description": "A Node.js binding for lp_solve",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "author": {
     "name": "Stephen Remde",
     "email": "smremde@gmail.com"


### PR DESCRIPTION
I just tried to install this package with node v6.9.1 and it failed, but allowing to use a newer non braking version of nan compiled successfully and the example ran through fine.